### PR TITLE
Adapt to Cassandra version to avoid CASSANDRA-8733

### DIFF
--- a/lib/cequel/metal/data_set.rb
+++ b/lib/cequel/metal/data_set.rb
@@ -187,8 +187,8 @@ module Cequel
       # @example
       #   posts.list_prepend(:categories, ['CQL', 'ORMs'])
       #
-      # @note If multiple elements are passed, they will appear in the list in
-      #   reverse order.
+      # @note A bug (CASSANDRA-8733) exists in Cassandra versions 0.3.0-2.0.12 and 2.1.0-2.1.2 which
+      #   will make elements appear in REVERSE ORDER in the list.
       # @note If a enclosed in a Keyspace#batch block, this method will be
       #   executed as part of the batch.
       # @see #list_append

--- a/lib/cequel/record/collection.rb
+++ b/lib/cequel/record/collection.rb
@@ -332,7 +332,8 @@ module Cequel
       #
       def unshift(*objects)
         objects.map!(&method(:cast_element))
-        to_update { updater.list_prepend(column_name, objects.reverse) }
+        prepared = @model.class.connection.bug8733_version? ? objects.reverse : objects
+        to_update { updater.list_prepend(column_name, prepared) }
         to_modify { super }
       end
       alias_method :prepend, :unshift


### PR DESCRIPTION
[PR From les]

This Cassandra bug causes list updates to reverse the order of the
array sent, which was being worked around in List#unshift by
reversing the array that was sent.

This change detects the version of Cassandra and only reverses
when it's a known buggy version. Also, the tests detect the
version and expect a list_prepend operation to produce reversed
lists in buggy versions.

See: https://issues.apache.org/jira/browse/CASSANDRA-8733
The bug was fixed in 2.1.3 and 2.0.13.

This code depends on the .cassandra-versions file to compile
a list of buggy versions, but doesn't add any other dependencies.

The following three tests now pass:
 Cequel::Record::List#unshift should persist unloaded unshift
 Cequel::Record::List#unshift should atomically unshift
 Cequel::Metal::DataSet#list_prepend should prepend multiple elements to list column

Tested on the following versions of Cassandra:
 2.0.4
 2.0.12
 2.0.13
 2.0.16
 2.1.2
 2.1.3
 2.1.8
 2.2.1
