### PR TITLE
Timestamp cast to milliseconds

### DIFF
--- a/lib/cequel/record/dirty.rb
+++ b/lib/cequel/record/dirty.rb
@@ -56,6 +56,10 @@ module Cequel
       private
 
       def write_attribute(name, value)
+        column = self.class.reflect_on_column(name)
+        fail UnknownAttributeError, "unknown attribute: #{name}" unless column
+        value = column.cast(value) unless value.nil?
+
         if loaded? && value != read_attribute(name)
           __send__("#{name}_will_change!")
         end

--- a/lib/cequel/type.rb
+++ b/lib/cequel/type.rb
@@ -379,7 +379,8 @@ module Cequel
 
     #
     # `timestamp` columns store timestamps. Timestamps do not include time zone
-    # data, and all input times are cast to UTC before being stored.
+    # data, and all input times are cast to UTC and rounded to the nearest
+    # millisecond before being stored.
     #
     # @see http://cassandra.apache.org/doc/cql3/CQL.html#usingdates
     #   CQL3 documentation for date columns
@@ -395,7 +396,7 @@ module Cequel
         elsif value.respond_to?(:to_time) then value.to_time
         elsif value.is_a?(Numeric) then Time.at(value)
         else Time.parse(value.to_s)
-        end.utc
+        end.utc.round(3)
       end
     end
     register Timestamp.instance

--- a/spec/examples/record/dirty_spec.rb
+++ b/spec/examples/record/dirty_spec.rb
@@ -6,14 +6,17 @@ describe Cequel::Record::Dirty do
     key :permalink, :text
     column :title, :text
     set :categories, :text
+    column :created_at, :timestamp
   end
 
   context 'loaded model' do
+    let(:created_at_float) { 1455754622.8502421 }
     let(:post) do
       Post.create!(
         permalink: 'cequel',
         title: 'Cequel',
-        categories: Set['Libraries']
+        categories: Set['Libraries'],
+        created_at: created_at_float
       )
     end
 
@@ -56,6 +59,11 @@ describe Cequel::Record::Dirty do
         {categories: [Set['Libraries'], Set['Libraries', 'Gems']]}.
         with_indifferent_access
       )
+    end
+
+    it 'should check dirty state against correctly cast timestamp values' do
+      post.created_at = created_at_float
+      expect(post.changed_attributes).to be_empty
     end
   end
 

--- a/spec/examples/record/timestamps_spec.rb
+++ b/spec/examples/record/timestamps_spec.rb
@@ -14,10 +14,10 @@ describe Cequel::Record::Timestamps do
     timestamps
   end
 
-  let!(:now) { Timecop.freeze }
+  let!(:now) { Timecop.freeze.round(3) }
 
   context 'with simple primary key' do
-    let(:blog) { Blog.create!(subdomain: 'bigdata') }
+    let!(:blog) { Blog.create!(subdomain: 'bigdata') }
 
     it 'should populate created_at after create new record' do
       expect(blog.created_at).to eq(now)
@@ -32,6 +32,10 @@ describe Cequel::Record::Timestamps do
       blog.name = 'name'
       blog.save!
       expect(blog.updated_at).to eq(future)
+    end
+
+    it 'should cast the timestamp in the same way that Cassandra records it' do
+      expect(Blog.first.updated_at).to eq(blog.updated_at)
     end
   end
 


### PR DESCRIPTION
Cassandra stores timestamps to a precision of milliseconds.

http://cassandra.apache.org/doc/cql3/CQL.html#usingtimestamps

Whereas Ruby allows Time objects to be more precise.

Before this change the timestamp value would often be different between
a model before it had been saved, and the same model once loaded from
Cassandra.

This would mean that the following would happen:

``` ruby
published_at = Time.now

post = Post.find(1)
post.published_at = published_at
post.save

post = Post.find(1)
post.published_at = published_at
post.changes.blank? # => false
```

Also, previously the check for if an attribute had changed was being
conducted on a non-casted value.

I've included two tests that previously would have failed.
