### PR TITLE
Attributes marked as dirty when assigned on a new object.

### DIFF
--- a/lib/cequel/record/properties.rb
+++ b/lib/cequel/record/properties.rb
@@ -343,6 +343,8 @@ module Cequel
         unless self.class.reflect_on_column(name)
           fail UnknownAttributeError, "unknown attribute: #{name}"
         end
+
+        send("#{name}_will_change!") unless value === read_attribute(name)
         @attributes[name] = value
       end
 

--- a/spec/examples/record/dirty_spec.rb
+++ b/spec/examples/record/dirty_spec.rb
@@ -59,12 +59,4 @@ describe Cequel::Record::Dirty do
     end
   end
 
-  context 'unloaded model' do
-    let(:post) { Post['cequel'] }
-
-    it 'should not track changes' do
-      post.title = 'Cequel'
-      expect(post.changes).to be_empty
-    end
-  end
 end

--- a/spec/examples/record/properties_spec.rb
+++ b/spec/examples/record/properties_spec.rb
@@ -53,6 +53,11 @@ describe Cequel::Record::Properties do
         title).to eq('Big Data')
     end
 
+    it 'should mark the attribute as dirty when setting attributes' do
+      expect(Post.new { |post| post.title = 'Big Data' }.changed).to eq(['title'])
+      expect(Post.new { |post| post.title = 'Big Data' }.changes).to eq({'title' => [nil,'Big Data']})
+    end
+
     it 'should get attributes with indifferent access' do
       post = Post.new.tap { |post| post.attributes = {:downcased_title => 'big data' }}
       expect(post.attributes[:title]).to eq 'Big Data'


### PR DESCRIPTION
This change brings Cequel models into line with regular ActiveRecord
model behaviour.

``` ruby
p = Post.new(title: 'My Post')
p.changes # => { 'title' => [nil, 'My Post'] }
```

Previously, this would only happen on objects that had been persisted.
